### PR TITLE
docs: expand README with repository layout, quick start and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,49 @@
 ![Project Screenshot](.images/screenshot.png)
 
 # Riley Boughners' Dotfiles
+
 ## About
-### Welcome to my dotfiles! These contain all of my most important configuration settings for all of my machines. I like trying to find the best balance of functionality and aesthetic. 
+Welcome to my dotfiles! These contain the configuration and automation I use across my machines. The goal is a balance of functionality and aesthetics.
+
+## Repository layout
+- `nixos/`: NixOS flake, system configuration, and Home Manager entry points.
+- `scripts/`: Helper scripts for rebuilding, theming, and syncing.
+- `dotfiles/`: Additional dotfiles (tracked for future expansion).
+- `.images/`: Screenshots showcased above.
+
+## Quick start
+> These instructions assume the repo is checked out as `~/.system`.
+
+1. Review the NixOS configuration:
+   - `nixos/flake.nix`
+   - `nixos/configuration.nix`
+   - `nixos/home-manager.nix`
+2. Rebuild the system:
+   ```bash
+   ~/.system/scripts/rebuild
+   ```
+3. Update and commit flake inputs:
+   ```bash
+   ~/.system/scripts/update
+   ```
+
+## Scripts
+| Script | Purpose |
+| --- | --- |
+| `scripts/rebuild` | Runs `nixos-rebuild switch` for the local flake. |
+| `scripts/update` | Updates flake inputs and commits `flake.lock` if it changed. |
+| `scripts/change-wallpaper` | Picks a wallpaper with Wofi, sets Hyprpaper, and updates the theme. |
+| `scripts/set-theme-from-wallpaper` | Runs `pywal` and applies colors to Firefox, Mako, and more. |
+| `scripts/backup` | Syncs backups from the `server` host with `rsync`. |
+| `scripts/cloud` | Mounts the `server` cloud directory with `sshfs`. |
+
+## Theming workflow
+1. Place wallpapers in `~/.wallpapers`.
+2. Run:
+   ```bash
+   ~/.system/scripts/change-wallpaper
+   ```
+3. The script copies the selected image to `~/.wallpaper`, updates Hyprpaper, and calls `set-theme-from-wallpaper`.
 
 ## TODO!
 


### PR DESCRIPTION
### Motivation
- Improve repository documentation so new and returning users can quickly understand layout, bootstrap steps, and the available helper scripts.
- Capture the theming workflow and link it to the existing scripts so the visual/configuration steps are easier to follow.

### Description
- Expanded `README.md` with a concise repository layout describing `nixos/`, `scripts/`, `dotfiles/`, and `.images/`.
- Added a `Quick start` section that assumes the repo is checked out as `~/.system` and shows how to run `~/.system/scripts/rebuild` and `~/.system/scripts/update`.
- Added a `Scripts` table documenting each helper script (including `scripts/rebuild`, `scripts/update`, `scripts/change-wallpaper`, `scripts/set-theme-from-wallpaper`, `scripts/backup`, and `scripts/cloud`).
- Documented the `Theming workflow` showing how to place wallpapers and run `~/.system/scripts/change-wallpaper` to update Hyprpaper and apply colors.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983a2bb53ec83249d30f54fbee756a6)