### PR TITLE
Add change-wallpaper alias and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ Welcome to my dotfiles! These contain the configuration and automation I use acr
 1. Place wallpapers in `~/.wallpapers`.
 2. Run:
    ```bash
-   ~/.system/scripts/change-wallpaper
+   change-wallpaper
    ```
 3. The script copies the selected image to `~/.wallpaper`, updates Hyprpaper, and calls `set-theme-from-wallpaper`.
 
 ## TODO!
 
-- [ ] create change-wallpaper command as an alias
+- [x] create change-wallpaper command as an alias

--- a/nixos/modules/shell.nix
+++ b/nixos/modules/shell.nix
@@ -52,6 +52,7 @@
       
       download = "nix run nixpkgs#yt-dlp -- -f bestaudio --extract-audio --audio-format best";
       unzip = "nix run nixpkgs#unzip";
+      change-wallpaper = "$HOME/.system/scripts/change-wallpaper";
 
     };
   };


### PR DESCRIPTION
### Motivation
- Provide a convenient `change-wallpaper` shell alias that runs the existing wallpaper script and reflect that change in documentation.

### Description
- Add `change-wallpaper = "$HOME/.system/scripts/change-wallpaper";` to `programs.zsh.shellAliases` in `nixos/modules/shell.nix` and update `README.md` to call `change-wallpaper` instead of the full script path and mark the TODO as complete.

### Testing
- No automated tests were run for this change; changes were limited to configuration and documentation only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983a506dae083248b6698712a144276)