### PR TITLE
fix: resolve nixvim evaluation warnings

### DIFF
--- a/nixos/modules/hyprland.nix
+++ b/nixos/modules/hyprland.nix
@@ -48,7 +48,7 @@
     pywal16
     imagemagick
     pywalfox-native
-    inputs.rose-pine-hyprcursor.packages.${pkgs.system}.default
+    inputs.rose-pine-hyprcursor.packages.${pkgs.stdenv.hostPlatform.system}.default
 
     #waybar
 

--- a/nixos/users/rileyboughner.nix
+++ b/nixos/users/rileyboughner.nix
@@ -12,12 +12,16 @@
 
   programs.home-manager.enable = true;
   home.packages = with pkgs; [
-    nixfmt-rfc-style
+    nixfmt
     stylua
   ];
 
   programs.nixvim = {
     enable = true;
+
+    # Reuse home-manager's pkgs instead of nixvim constructing its own from
+    # a pinned/followed nixpkgs source (avoids the nixpkgs-follows mismatch warning).
+    nixpkgs.useGlobalPackages = true;
 
     extraPlugins = [
       pkgs.vimPlugins.pywal-nvim
@@ -107,6 +111,9 @@
 
       # File searching
       telescope.enable = true;
+
+      # Icons (used by telescope); explicit to avoid the deprecated auto-enable warning
+      web-devicons.enable = true;
 
       # Status bar
       lualine.enable = true;


### PR DESCRIPTION
- Set programs.nixvim.nixpkgs.useGlobalPackages = true so nixvim reuses home-manager's pkgs instead of constructing its own from a followed nixpkgs input, which was mismatched against nixvim's pinned rev.
- Explicitly enable plugins.web-devicons instead of relying on telescope's deprecated auto-enable behavior.
- Also cleaned up two adjacent eval warnings surfaced in the same build: pkgs.system -> pkgs.stdenv.hostPlatform.system in modules/hyprland.nix, and nixfmt-rfc-style -> nixfmt (now an alias) in home.packages.

Verified with `nixos-rebuild dry-build --flake ./nixos#laptop --impure`: zero evaluation warnings, down from 4 distinct warnings before.