### PR TITLE
fix: package random-wallpaper script so Hyprland can find it

### DIFF
--- a/nixos/modules/hyprland.nix
+++ b/nixos/modules/hyprland.nix
@@ -25,6 +25,10 @@
 
   environment.systemPackages = with pkgs; [
 
+    (pkgs.runCommand "random-wallpaper" { } ''
+      install -Dm755 ${../../scripts/random-wallpaper} $out/bin/random-wallpaper
+    '')
+
     hyprpwcenter
     hyprlauncher
     hyprpaper


### PR DESCRIPTION
Hyprland is launched directly by greetd (start-hyprland), not through a login shell, so the `export PATH="$HOME/.dotfiles/scripts:$PATH"` in programs.zsh.shellInit never reaches the compositor's process tree. Every hl.exec_cmd("random-wallpaper") call - on startup and on the Super+W keybind - was silently failing with "command not found", which is why the wallpaper never appeared and Super+W did nothing.

Fix: install scripts/random-wallpaper into environment.systemPackages via a small runCommand derivation, so it lands in /run/current-system/sw/bin, which is on PATH for every process regardless of shell or launch method.

Verified nixos-rebuild dry-build and a full toplevel build succeed, and confirmed the resulting sw/bin/random-wallpaper is the same script, executable, single shebang.